### PR TITLE
fix(provider/azure): Failed to delete firewall

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DeleteSecurityGroupStage.groovy
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/DeleteSecurityGroupStage.groovy
@@ -32,7 +32,7 @@ class DeleteSecurityGroupStage implements StageDefinitionBuilder {
   void taskGraph(Stage stage, TaskNode.Builder builder) {
     builder
       .withTask("deleteSecurityGroup", DeleteSecurityGroupTask)
-      .withTask("forceCacheRefresh", DeleteSecurityGroupForceRefreshTask)
       .withTask("monitorDelete", MonitorKatoTask)
+      .withTask("forceCacheRefresh", DeleteSecurityGroupForceRefreshTask)
   }
 }


### PR DESCRIPTION
Background:
Currently it failed to delete firewall and throw timeout exception at force cache stage while deleting firewall. After investigated, delete firewall task and force cache refresh task would be processed concurrently. If delete firewall task doesn't get the response from azure within 20 seconds, then force cache refresh task would throw timeout exception.
Fix:
So update the execution order for deleting firewall. After updated, force cache refresh task will be processed when monitor delete task is completed. After tested, now it can delete firewall successfully.
